### PR TITLE
Fix to issue #10, #7 and #2

### DIFF
--- a/docs/tutorials/new_dataset.md
+++ b/docs/tutorials/new_dataset.md
@@ -261,6 +261,8 @@ There two ways to concatenate the dataset.
     )
     ```
 
+    If the concatenated dataset is used for test or evaluation, this manner supports to evaluate each dataset separately.
+
 2. In case the dataset you want to concatenate is different, you can concatenate the dataset configs like the following.
 
     ```python
@@ -278,6 +280,27 @@ There two ways to concatenate the dataset.
         test = dataset_A_test
         )
     ```
+    If the concatenated dataset is used for test or evaluation, this manner also supports to evaluate each dataset separately.
+
+3. We also support to define `ConcatDataset` explicitly as the following.
+
+    ```python
+    dataset_A_val = dict()
+    dataset_B_val = dict()
+
+    data = dict(
+        imgs_per_gpu=2,
+        workers_per_gpu=2,
+        train=dataset_A_train,
+        val=dict(
+            type='ConcatDataset',
+            datasets=[dataset_A_val, dataset_B_val],
+            separate_eval=False,
+        )
+    )
+    ```
+    This manner allows users to evaluate the all the datasets as a single one by setting `separate_eval=False`.
+    This option assumes the dataset uses `self.data_infos` during evaluation. Therefore, COCO datasets does not support this behavior since COCO datasets do not fully rely on `self.data_infos` during evaluation. Combining different type of datasets and evaluating them as a whole is not tested.
 
 
 A more complex example that repeats `Dataset_A` and `Dataset_B` by N and M times, respectively, and then concatenates the repeated datasets is as the following.

--- a/mmdet/__init__.py
+++ b/mmdet/__init__.py
@@ -16,7 +16,7 @@ def digit_version(version_str):
 
 
 mmcv_minimum_version = '1.0.5'
-mmcv_maximum_version = '1.0.5'
+mmcv_maximum_version = '2.3.0'
 mmcv_version = digit_version(mmcv.__version__)
 
 

--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -73,8 +73,8 @@ class LoadImage(object):
         results['ori_shape'] = img.shape
         return results
 
-
 def inference_detector(model, img):
+    #quick & dirty fix
     """Inference image(s) with the detector.
 
     Args:
@@ -87,6 +87,48 @@ def inference_detector(model, img):
         detection results directly.
     """
     cfg = model.cfg
+    device = next(model.parameters()).device  # model device
+    # build the data pipeline
+    test_pipeline = [LoadImage()] + cfg.data.test.pipeline[1:]
+    test_pipeline = Compose(test_pipeline)
+    # prepare data
+    data = dict(img=img)
+    data = test_pipeline(data)
+    data = collate([data], samples_per_gpu=1)
+    if next(model.parameters()).is_cuda:
+        # scatter to specified GPU
+        data = scatter(data, [device])[0]
+    else:
+        # Use torchvision ops for CPU mode instead
+        for m in model.modules():
+            if isinstance(m, (RoIPool, RoIAlign)):
+                if not m.aligned:
+                    # aligned=False is not implemented on CPU
+                    # set use_torchvision on-the-fly
+                    m.use_torchvision = True
+        warnings.warn('We set use_torchvision=True in CPU mode.')
+        # just get the actual data from DataContainer
+        data['img_metas'] = data['img_metas'][0].data
+
+    # forward the model
+    with torch.no_grad():
+        result = model(return_loss=False, rescale=True, **data)
+    return result
+
+def inference_detector(model, cfg, img):
+    #quick & dirty fix
+    """Inference image(s) with the detector.
+
+    Args:
+        model (nn.Module): The loaded detector.
+        imgs (str/ndarray or list[str/ndarray]): Either image files or loaded
+            images.
+
+    Returns:
+        If imgs is a str, a generator will be returned, otherwise return the
+        detection results directly.
+    """
+    #cfg = model.cfg
     device = next(model.parameters()).device  # model device
     # build the data pipeline
     test_pipeline = [LoadImage()] + cfg.data.test.pipeline[1:]

--- a/mmdet/datasets/builder.py
+++ b/mmdet/datasets/builder.py
@@ -60,6 +60,10 @@ def build_dataset(cfg, default_args=None):
                                    ClassBalancedDataset)
     if isinstance(cfg, (list, tuple)):
         dataset = ConcatDataset([build_dataset(c, default_args) for c in cfg])
+    elif cfg['type'] == 'ConcatDataset':
+        dataset = ConcatDataset(
+            [build_dataset(c, default_args) for c in cfg['datasets']],
+            cfg.get('separate_eval', True))
     elif cfg['type'] == 'RepeatDataset':
         dataset = RepeatDataset(
             build_dataset(cfg['dataset'], default_args), cfg['times'])

--- a/mmdet/datasets/dataset_wrappers.py
+++ b/mmdet/datasets/dataset_wrappers.py
@@ -3,6 +3,7 @@ import math
 from collections import defaultdict
 
 import numpy as np
+from mmcv.utils import print_log
 from torch.utils.data.dataset import ConcatDataset as _ConcatDataset
 
 from .builder import DATASETS
@@ -19,9 +20,19 @@ class ConcatDataset(_ConcatDataset):
         datasets (list[:obj:`Dataset`]): A list of datasets.
     """
 
-    def __init__(self, datasets):
+    def __init__(self, datasets, separate_eval=True):
         super(ConcatDataset, self).__init__(datasets)
         self.CLASSES = datasets[0].CLASSES
+        self.separate_eval = separate_eval
+        if not separate_eval:
+            if any([ds['type'] == 'CocoDataset' for ds in datasets]):
+                raise NotImplementedError(
+                    'Evaluating concatenated CocoDataset as a whole is not'
+                    ' supported! Please set "separate_eval=True"')
+            elif len(set([ds['type'] for ds in datasets])) != 1:
+                raise NotImplementedError(
+                    'All the datasets should have same types')
+
         if hasattr(datasets[0], 'flag'):
             flags = []
             for i in range(0, len(datasets)):
@@ -50,6 +61,56 @@ class ConcatDataset(_ConcatDataset):
             sample_idx = idx - self.cumulative_sizes[dataset_idx - 1]
         return self.datasets[dataset_idx].get_cat_ids(sample_idx)
 
+    def evaluate(self, results, metric, logger=None, **kwargs):
+        """Evaluate the results.
+        Args:
+            results (list[list | tuple]): Testing results of the dataset.
+            metric (str | list[str]): Metrics to be evaluated. Options are
+                'bbox', 'segm', 'proposal', 'proposal_fast'.
+            logger (logging.Logger | str | None): Logger used for printing
+                related information during evaluation. Default: None.
+        Returns:
+            dict[str: float]: AP results of the total dataset or each separate
+            dataset if `self.separate_eval=True`.
+        """
+        assert len(results) == self.cumulative_sizes[-1], \
+            f'wrong sizes{self.cumulative_sizes[-1]} v.s. {len(results)}'
+
+        if self.separate_eval:
+            dataset_idx = -1
+            total_eval_results = dict()
+            for size, dataset in zip(self.cumulative_sizes, self.datasets):
+                start_idx = 0 if dataset_idx == -1 else \
+                    self.cumulative_sizes[dataset_idx]
+                end_idx = self.cumulative_sizes[dataset_idx + 1]
+
+                results_per_dataset = results[start_idx:end_idx]
+                print_log(
+                    f'\nEvaluateing {dataset.ann_file} with '
+                    f'{len(results_per_dataset)} images now',
+                    logger=logger)
+
+                eval_results_per_dataset = dataset.evaluate(
+                    results_per_dataset, **kwargs)
+                dataset_idx += 1
+                for k, v in eval_results_per_dataset:
+                    total_eval_results.update({f'{k}_{dataset_idx}': v})
+
+            return total_eval_results
+        elif any([ds['type'] == 'CocoDataset' for ds in self.datasets]):
+            raise NotImplementedError(
+                'Evaluating concatenated CocoDataset as a whole is not'
+                ' supported! Please set "separate_eval=True"')
+        elif len(set([ds['type'] for ds in self.datasets])) != 1:
+            raise NotImplementedError(
+                'All the datasets should have same types')
+        else:
+            original_data_infos = self.datasets[0].data_infos
+            self.dataset[0].data_infos = sum(
+                [dataset.data_infos for dataset in self.datasets], [])
+            eval_results = self.dataset[0].evaluate(results, metric, **kwargs)
+            self.dataset[0].data_infos = original_data_infos
+            return eval_results
 
 @DATASETS.register_module()
 class RepeatDataset(object):
@@ -135,8 +196,10 @@ class ClassBalancedDataset(object):
 
         repeat_factors = self._get_repeat_factors(dataset, oversample_thr)
         repeat_indices = []
-        for dataset_index, repeat_factor in enumerate(repeat_factors):
-            repeat_indices.extend([dataset_index] * math.ceil(repeat_factor))
+        #for dataset_index, repeat_factor in enumerate(repeat_factors):
+        #    repeat_indices.extend([dataset_index] * math.ceil(repeat_factor))
+        for dataset_idx, repeat_factor in enumerate(repeat_factors):
+            repeat_indices.extend([dataset_idx] * math.ceil(repeat_factor))
         self.repeat_indices = repeat_indices
 
         flags = []

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,4 @@
 albumentations>=0.3.2
 cityscapesscripts
 imagecorruptions
-lvis@git+https://github.com/open-mmlab/cocoapi.git#subdirectory=lvis
+lvis

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,5 @@
 matplotlib
 numpy
-pycocotools@git+https://github.com/open-mmlab/cocoapi.git#subdirectory=pycocotools
+mmpycocotools@12.0.3
 six
 terminaltables

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,5 @@
 matplotlib
 numpy
-mmpycocotools@12.0.3
+mmpycocotools
 six
 terminaltables

--- a/tools/bonai/bonai_inference_test.py
+++ b/tools/bonai/bonai_inference_test.py
@@ -1,0 +1,44 @@
+import argparse
+import os
+import warnings
+
+import mmcv
+import torch
+from mmcv import Config, DictAction
+from mmcv.runner import get_dist_info, init_dist, load_checkpoint
+from tools.fuse_conv_bn import fuse_module
+
+from mmdet.apis import inference_detector
+from mmdet.core import wrap_fp16_model
+from mmdet.datasets import build_dataloader, build_dataset
+from mmdet.models import build_detector
+
+config_file = '../../configs/loft_foa/loft_foa_r50_fpn_2x_bonai.py'
+#config_file = '../../configs/_base_/models/bonai_loft_foa_r50_fpn_basic.py'
+config_file = '../../work_dirs/loft_foa_r50_fpn_2x_bonai/loft_foa_r50_fpn_2x_bonai.py'
+checkpoint_file = '../../work_dirs/loft_foa_r50_fpn_2x_bonai/loft_foa_r50_fpn_2x_bonai_1-544d6bf6.pth'
+cfg = Config.fromfile(config_file)
+
+model = build_detector(cfg.model, test_cfg=cfg.test_cfg)
+fp16_cfg = cfg.get('fp16', None)
+if fp16_cfg is not None:
+    wrap_fp16_model(model)
+checkpoint = load_checkpoint(model, checkpoint_file, map_location='cuda')
+#model = fuse_module(model)
+model.CLASSES = checkpoint['meta']['CLASSES']
+
+model.with_vis_feat = False
+# test a single image and show the results
+img = './test.png'  # or img = mmcv.imread(img), which will only load it once
+
+model.eval()
+
+result = inference_detector(model, cfg, img)
+#print("result = ", result)
+#with torch.no_grad():
+#    result = model(return_loss=False, rescale=True, **data)
+
+# visualize the results in a new window
+#model.show_result(img, result)
+# or save the visualization results to image files
+model.show_result(img, result, out_file='./result.png')

--- a/train.sh
+++ b/train.sh
@@ -1,0 +1,2 @@
+python tools/train.py configs/loft_foa/loft_foa_r50_fpn_2x_bonai.py --resume work_dirs/loft_foa_r50_fpn_2x_bonai/epoch_3.pth
+


### PR DESCRIPTION
A quick & dirty fix.
mmcv-full 1.7.2, mmlvis 10.5.3 and mmpycocotools 12.0.3 have to be built from source, and pycocotools should be uninstalled manually.
When building mmpycocotools, there is an error in linking, caused by two maskApi.o. The quick and dirty fix is running:
`cc -pthread -B /home/akiko/miniconda3/envs/bonai/compiler_compat -shared -Wl,-rpath,/home/akiko/miniconda3/envs/bonai/lib -Wl,-rpath-link,/home/akiko/miniconda3/envs/bonai/lib -L/home/akiko/miniconda3/envs/bonai/lib -Wl,-rpath,/home/akiko/miniconda3/envs/bonai/lib -Wl,-rpath-link,/home/akiko/miniconda3/envs/bonai/lib -L/home/akiko/miniconda3/envs/bonai/lib build/temp.linux-x86_64-cpython-310/../common/maskApi.o  build/temp.linux-x86_64-cpython-310/pycocotools/_mask.o -o build/lib.linux-x86_64-cpython-310/pycocotools/_mask.cpython-310-x86_64-linux-gnu.so`
then pip install -e .
When building mmcv-full, use the following commands:
`MMCV_WITH_OPS=1 FORCE_CUDA=1 pip install -e . -v`
You need an environment with CUDA=11.7 and pytorch=1.13.1. A working nvcc=11.7.x is required. If your system have both CUDA 12 and 11, do following:
`export PATH="/usr/local/cuda-11/bin:$PATH"
export LD_LIBRARY_PATH="/usr/local/cuda-11/lib64:$LD_LIBRARY_PATH"`
Conda will not solve everything here.